### PR TITLE
Calculate displayedInterval based on weekStartsOn

### DIFF
--- a/src/datepicker/DayPicker.vue
+++ b/src/datepicker/DayPicker.vue
@@ -108,8 +108,12 @@ export default defineComponent({
     }))
 
     const displayedInterval = computed(() => ({
-      start: startOfWeek(monthStart.value),
-      end: endOfWeek(monthEnd.value),
+      start: startOfWeek(monthStart.value, {
+        weekStartsOn: props.weekStartsOn,
+      }),
+      end: endOfWeek(monthEnd.value, {
+        weekStartsOn: props.weekStartsOn,
+      }),
     }))
 
     const weekDays = computed(() => {


### PR DESCRIPTION
I noticed a small issue where the dates in the DayPicker would not change when `weekStartsOn` was changed (and were already wrong with the default of the prop,[ since date-fns takes zero as the default.](https://date-fns.org/v2.16.1/docs/startOfWeek))