### PR TITLE
Added formatting to the Month view

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,18 +1,31 @@
 <template>
   <img alt="Vue logo" src="./assets/logo.png" />
   <div>
-    <datepicker class="picker" v-model="selected" :locale="locale" :upperLimit="to" :lowerLimit="from" />
+    <datepicker
+      class="picker"
+      v-model="selected"
+      :locale="locale"
+      :upperLimit="to"
+      :lowerLimit="from"
+    />
   </div>
   <div>
-    <datepicker class="picker" weekday-format="iiiiii" v-model="from" :locale="locale" placeholder="from" />
+    <datepicker
+      class="picker"
+      weekday-format="iiiiii"
+      month-list-format="LLLL"
+      v-model="from"
+      :locale="locale"
+      placeholder="from"
+    />
   </div>
   <div>
-    <datepicker class="picker" v-model="to" :locale="locale" placeholder="to" />
+    <datepicker class="picker" v-model="to" placeholder="to" />
   </div>
 </template>
 
 <script>
-import Datepicker from './components/Datepicker.vue'
+import Datepicker from './datepicker/Datepicker.vue'
 import { defineComponent } from 'vue'
 import { ru } from 'date-fns/locale'
 
@@ -25,7 +38,7 @@ export default defineComponent({
     return {
       selected: null,
       from: null,
-      to: null
+      to: null,
     }
   },
   computed: {

--- a/src/datepicker/Datepicker.vue
+++ b/src/datepicker/Datepicker.vue
@@ -15,7 +15,6 @@
       :selected="modelValue"
       :lowerLimit="lowerLimit"
       :upperLimit="upperLimit"
-      :locale="locale"
       @select="selectYear"
     />
     <month-picker
@@ -25,6 +24,7 @@
       @select="selectMonth"
       :lowerLimit="lowerLimit"
       :upperLimit="upperLimit"
+      :format="monthListFormat"
       :headingFormat="monthHeadingFormat"
       :locale="locale"
       @back="viewShown = 'year'"
@@ -100,6 +100,14 @@ export default defineComponent({
       type: String,
       required: false,
       default: 'LLLL yyyy',
+    },
+    /**
+     * `date-fns`-type formatting for the month picker view
+     */
+    monthListFormat: {
+      type: String,
+      required: false,
+      default: 'LLL',
     },
     /**
      * `date-fns`-type formatting for a line of weekdays on day view

--- a/src/datepicker/MonthPicker.vue
+++ b/src/datepicker/MonthPicker.vue
@@ -34,6 +34,7 @@ import {
   isValid,
 } from 'date-fns'
 import PickerPopup from './PickerPopup.vue'
+import { formatWithOptions } from 'date-fns/fp'
 
 export default defineComponent({
   components: {
@@ -59,7 +60,11 @@ export default defineComponent({
     format: {
       type: String,
       required: false,
-      default: 'MMM',
+      default: 'LLL',
+    },
+    locale: {
+      type: Object as PropType<Locale>,
+      required: false,
     },
     lowerLimit: {
       type: Date as PropType<Date>,
@@ -73,6 +78,12 @@ export default defineComponent({
   setup(props, { emit }) {
     const from = computed(() => startOfYear(props.pageDate))
     const to = computed(() => endOfYear(props.pageDate))
+
+    const format = computed(() =>
+      formatWithOptions({
+        locale: props.locale,
+      })(props.format)
+    )
 
     const isEnabled = (
       target: Date,
@@ -91,8 +102,8 @@ export default defineComponent({
         end: to.value,
       }).map((value) => ({
         value,
-        display: format(value, props.format),
-        key: format(value, props.format),
+        display: format.value(value),
+        key: format.value(value),
         selected: props.selected && isSameMonth(props.selected, value),
         disabled: !isEnabled(value, props.lowerLimit, props.upperLimit),
       }))


### PR DESCRIPTION
MonthPicker doesn't depend on picked locale at the moment. This PR fixes the issue and adds `monthListFormat`, which enables format specifying for the MonthPicker

fixes #7