### PR TITLE
Add minimumView props

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Full props documentation is available at https://icehaunter.github.io/vue3-datep
 |`lowerLimit`|`Date`||Lower limit for available dates for picking|
 |`disabledDates`|`{ dates: Date[] }`||Dates not available for picking|
 |`startingView`| `'day' \| 'month' \| 'year'` | `'day'` |View on which the date picker should open. Can be either `year`, `month`, or `day` |
+|`minimumView`| `'day' \| 'month' \| 'year'` | `'day'` |If set, lower-level views won't show |
 | `monthHeadingFormat` | `String` | `LLLL yyyy` | `date-fns`-type formatting for a month view heading
 | `weekdayFormat` | `String` | `EE` | `date-fns`-type formatting for a line of weekdays on day view
 | `inputFormat` | `String` | `yyyy-MM-dd` | `date-fns`-type format in which the string in the input should be both parsed and displayed |

--- a/src/App.vue
+++ b/src/App.vue
@@ -46,6 +46,7 @@
       v-model="monthSelected"
       :locale="locale"
       minimum-view="month"
+      starting-view="year"
       placeholder="selectMonth"
     />
   </div>

--- a/src/App.vue
+++ b/src/App.vue
@@ -31,6 +31,24 @@
       placeholder="disabled"
     />
   </div>
+  <div>
+    <datepicker
+      class="picker"
+      v-model="yearSelected"
+      :locale="locale"
+      minimum-view="year"
+      placeholder="selectYear"
+    />
+  </div>
+  <div>
+    <datepicker
+      class="picker"
+      v-model="monthSelected"
+      :locale="locale"
+      minimum-view="month"
+      placeholder="selectMonth"
+    />
+  </div>
 </template>
 
 <script>
@@ -48,6 +66,8 @@ export default defineComponent({
       selected: null,
       from: null,
       to: null,
+      yearSelected: null,
+      monthSelected: null,
     }
   },
   computed: {

--- a/src/datepicker/Datepicker.vue
+++ b/src/datepicker/Datepicker.vue
@@ -9,8 +9,8 @@
       :disabled="disabled"
       :tabindex="disabled ? -1 : 0"
       @blur="renderView()"
-      @focus="renderView(startingView)"
-      @click="renderView(startingView)"
+      @focus="renderView(initialView)"
+      @click="renderView(initialView)"
     />
     <year-picker
       v-show="viewShown === 'year'"
@@ -166,6 +166,16 @@ export default defineComponent({
       required: false,
       default: false,
     },
+    /**
+     * If set, lower-level views won't show
+     */
+    minimumView: {
+      type: String as PropType<'year' | 'month' | 'day'>,
+      required: false,
+      default: 'day',
+      validate: (v: unknown) =>
+        typeof v === 'string' && ['day', 'month', 'year'].includes(v),
+    },
   },
   emits: {
     'update:modelValue': (value: Date | null | undefined) =>
@@ -199,17 +209,33 @@ export default defineComponent({
     })
     const selectYear = (date: Date) => {
       pageDate.value = date
-      viewShown.value = 'month'
+
+      if (props.minimumView === 'year') {
+        viewShown.value = 'none'
+        emit('update:modelValue', date)
+      } else {
+        viewShown.value = 'month'
+      }
     }
     const selectMonth = (date: Date) => {
       pageDate.value = date
-      viewShown.value = 'day'
+
+      if (props.minimumView === 'month') {
+        viewShown.value = 'none'
+        emit('update:modelValue', date)
+      } else {
+        viewShown.value = 'day'
+      }
     }
     const selectDay = (date: Date) => {
       emit('update:modelValue', date)
 
       viewShown.value = 'none'
     }
+
+    const initialView = computed(() => {
+      return props.startingView === props.minimumView ? props.startingView : props.minimumView
+    })
 
     return {
       input,
@@ -219,6 +245,7 @@ export default defineComponent({
       selectMonth,
       selectDay,
       viewShown,
+      initialView,
       log: (e: any) => console.log(e),
     }
   },

--- a/src/datepicker/Datepicker.vue
+++ b/src/datepicker/Datepicker.vue
@@ -55,6 +55,8 @@ import YearPicker from './YearPicker.vue'
 import MonthPicker from './MonthPicker.vue'
 import DayPicker from './DayPicker.vue'
 
+const TIME_RESOLUTIONS = ['day', 'month', 'year']
+
 export default defineComponent({
   components: {
     YearPicker,
@@ -103,7 +105,7 @@ export default defineComponent({
       required: false,
       default: 'day',
       validate: (v: unknown) =>
-        typeof v === 'string' && ['day', 'month', 'year'].includes(v),
+        typeof v === 'string' && TIME_RESOLUTIONS.includes(v),
     },
     /**
      * `date-fns`-type formatting for a month view heading
@@ -174,8 +176,8 @@ export default defineComponent({
       required: false,
       default: 'day',
       validate: (v: unknown) =>
-        typeof v === 'string' && ['day', 'month', 'year'].includes(v),
-    },
+        typeof v === 'string' && TIME_RESOLUTIONS.includes(v),
+    }
   },
   emits: {
     'update:modelValue': (value: Date | null | undefined) =>
@@ -234,7 +236,12 @@ export default defineComponent({
     }
 
     const initialView = computed(() => {
-      return props.startingView === props.minimumView ? props.startingView : props.minimumView
+      const startingViewOrder = TIME_RESOLUTIONS.indexOf(props.startingView)
+      const minimumViewOrder = TIME_RESOLUTIONS.indexOf(props.minimumView)
+
+      return startingViewOrder < minimumViewOrder
+        ? props.minimumView
+        : props.startingView
     })
 
     return {


### PR DESCRIPTION
I added `minimumView` property into `Datepicker.vue`. If set, lower-level views won't show.
This property behaves like the same one as `charliekassel/vuejs-datepicker`.