### PR TITLE
Fix location of types file

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   "main": "dist/vue3-datepicker.cjs.js",
   "module": "dist/vue3-datepicker.esm.js",
   "style": "dist/vue3-datepicker.css",
-  "types": "dist/Datepicker.vue.d.ts",
+  "types": "dist/src/datepicker/Datepicker.vue.d.ts",
   "files": [
     "src/datepicker",
     "dist"


### PR DESCRIPTION
Fix a small regression from v0.2.0.
Upon build, the type declaration is no longer present at `dist/Datepicker.vue.d.ts` but at `dist/src/datepicker/Datepicker.vue.d.ts`