### PR TITLE
Updated inputFormat behavior to match documentation

### DIFF
--- a/src/datepicker/Datepicker.vue
+++ b/src/datepicker/Datepicker.vue
@@ -50,7 +50,7 @@
 
 <script lang="ts">
 import { defineComponent, ref, computed, watchEffect, PropType } from 'vue'
-import { parse, isValid, setYear, lightFormat } from 'date-fns'
+import { parse, isValid, setYear, format } from 'date-fns'
 import YearPicker from './YearPicker.vue'
 import MonthPicker from './MonthPicker.vue'
 import DayPicker from './DayPicker.vue'
@@ -199,7 +199,7 @@ export default defineComponent({
       () =>
         (input.value =
           props.modelValue && isValid(props.modelValue)
-            ? lightFormat(props.modelValue, props.inputFormat)
+            ? format(props.modelValue, props.inputFormat, {locale: props.locale})
             : '')
     )
 


### PR DESCRIPTION
This update is for the `inputFormat` property of the datepicker. The update will make the expected behavior match the project's official documentation, https://icehaunter.github.io/vue3-datepicker/config.html#inputformat.  

The existing behavior is limited to patterns supported by `lightFormat`, https://date-fns.org/v2.19.0/docs/fp/lightFormat. This update will allow a user to select any pattern permitted by `format` https://date-fns.org/v2.19.0/docs/format. 

The existing locale object is now passed in as an option to `format`. This will give better international support. In my local tests, month names displayed in the input translated correctly to the two languages I tested, French and Spanish. I would run unit tests, but I'm not sure of the best way to run one for a datepicker.

If there any issues with this change, please let me know.