### PR TITLE
Added Example section in README.md file 

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Package is transpiled and should be usable for everyone with ES6 and above, but 
 
 
 ## Example
-```
+```vue
 <template>
   <datepicker v-model="picked" />
 </template>

--- a/README.md
+++ b/README.md
@@ -56,3 +56,24 @@ Full props documentation is available at https://icehaunter.github.io/vue3-datep
 ## Compatibility
 
 Package is transpiled and should be usable for everyone with ES6 and above, but the styling of the datepicker itself uses CSS Grid and CSS variables.
+
+
+## Example
+```
+<template>
+  <datepicker v-model="picked" />
+</template>
+
+
+<script>
+import Datepicker from '../src/datepicker/Datepicker.vue'
+components: {
+  Datepicker
+},
+data(): {
+  return {
+    picked: new Date();
+  }
+}
+</script>
+```


### PR DESCRIPTION
I have added an example explaining how to use this package. I was having difficulty and facing some errors in the following example which is used on the website.

```vue
<script setup>
import Datepicker from 'vue3-datepicker'
import { ref } from 'vue'
const picked = ref(new Date())
</script>

<template>
  <datepicker v-model="picked" />
</template>
```

So for the user guide, I have added an example that is working for me in Vue 3.