### PR TITLE
Added keyboard input mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ Full props documentation is available at https://icehaunter.github.io/vue3-datep
 | `weekdayFormat` | `String` | `EE` | `date-fns`-type formatting for a line of weekdays on day view
 | `inputFormat` | `String` | `yyyy-MM-dd` | `date-fns`-type format in which the string in the input should be both parsed and displayed |
 | `locale` | [`Locale`](https://date-fns.org/v2.16.1/docs/I18n#usage) | `date-fns/locale/en` | [`date-fns` locale object](https://date-fns.org/v2.16.1/docs/I18n#usage). Used in string formatting (see default `monthHeadingFormat`)
+| `disabled` | `Boolean` | `false` | Disables datepicker and prevents it's opening
+| `typeable` | `Boolean` | `false` | Allows user to input date manually
 | `weekStartsOn` | `Number` | 1 | Day on which the week should start. Number from 0 to 6, where 0 is Sunday and 6 is Saturday. Week starts with a Monday (1) by default |
 
 ## Compatibility

--- a/docs/config.md
+++ b/docs/config.md
@@ -71,6 +71,20 @@ Used in all date string formatting (e.g. see default `monthHeadingFormat`)
 
 Day on which the week should start. Number from 0 to 6, where 0 is Sunday and 6 is Saturday. Week starts with a Monday (1) by default.
 
+### `disabled`
+
+- Type: `Boolean`
+- Default: `false`
+
+Disables datepicker and prevents it's opening
+
+### `typeable`
+
+- Type: `Boolean`
+- Default: `false`
+
+Allows user to input date manually
+
 ## Styling
 
 The input itself can be styled via passing classes to it. [Attribute fallthrough](https://v3.vuejs.org/guide/component-attrs.html#disabling-attribute-inheritance) is enabled. Keep in mind that input itself is not a top-level element, as it is contained within the top-level `div`.

--- a/docs/index.md
+++ b/docs/index.md
@@ -66,6 +66,8 @@ More in-depth documentation of the props, as well as examples, can be found in [
 | `weekdayFormat` | `String` | `EE` | `date-fns`-type formatting for a line of weekdays on day view
 | `inputFormat` | `String` | `yyyy-MM-dd` | `date-fns`-type format in which the string in the input should be both parsed and displayed |
 | `locale` | [`Locale`](https://date-fns.org/v2.16.1/docs/I18n#usage) | `date-fns/locale/en` | [`date-fns` locale object](https://date-fns.org/v2.16.1/docs/I18n#usage). Used in string formatting (see default `monthHeadingFormat`)
+| `disabled` | `Boolean` | `false` | Disables datepicker and prevents it's opening
+| `typeable` | `Boolean` | `false` | Allows user to input date manually
 | `weekStartsOn` | `Number` | 1 | Day on which the week should start. Number from 0 to 6, where 0 is Sunday and 6 is Saturday. Week starts with a Monday (1) by default |
 
 ## Styling


### PR DESCRIPTION
### What's new?
Added possibility to input dates via keyboard. Added triggers to close calendar via `escape` or `enter` buttons.

### What's changed?
Updated docs, README and config.

### How to use?
```vue
<script setup>
import Datepicker from 'vue3-datepicker'
import { ref } from 'vue'

const date = ref(new Date())
</script>

<template>
  <datepicker v-model="date" :typeable="true" />
</template>
```

### Related issues

Close #18

