### PR TITLE
Removed unnecessary curly braces around some :clearable props

### DIFF
--- a/docs/examples.md
+++ b/docs/examples.md
@@ -149,7 +149,7 @@ Result:
   <template>
     <datepicker
       v-model="pickedDate"
-      :clearable="{ true }"
+      :clearable="true"
     />
   </template>
   ```
@@ -171,7 +171,7 @@ We can customize clearable view with `slot` for example:
   <template>
     <datepicker
       v-model="pickedDate"
-      :clearable="{ true }"
+      :clearable="true"
     >
       <template v-slot:clear="{ onClear }">
         <button @click="onClear">x</button>


### PR DESCRIPTION
Please correct me if I'm wrong here, but did some testing and from my perspective there's a typo around some of the :clearable props that just need a boolean and not expect a variable called "true" or "false" :)