### PR TITLE
init page after lowerLimit when opening picker

### DIFF
--- a/src/datepicker/Datepicker.vue
+++ b/src/datepicker/Datepicker.vue
@@ -232,7 +232,11 @@ export default defineComponent({
     )
 
     const renderView = (view: typeof viewShown.value = 'none') => {
-      if (!props.disabled) viewShown.value = view
+      if (!props.disabled) {
+        if(view !== 'none' && viewShown.value === 'none')
+          pageDate.value = props.modelValue || props.lowerLimit || new Date()
+        viewShown.value = view
+      }
     }
     watchEffect(() => {
       if (props.disabled) viewShown.value = 'none'


### PR DESCRIPTION
When opening the DatePicker the lowerLimit date is not taken into account to init pageDate. So there can be no selectable date on the first page.

I can also add a new prop to activate this behavior if it's better.

Thanks for your great job.

