### PR TITLE
Allow Clicking dates in Previous/Future Months

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ Full props documentation is available at https://icehaunter.github.io/vue3-datep
 | `typeable` | `Boolean` | `false` | Allows user to input date manually
 | `weekStartsOn` | `Number` | 1 | Day on which the week should start. Number from 0 to 6, where 0 is Sunday and 6 is Saturday. Week starts with a Monday (1) by default |
 | `clearable` | `Boolean` | `false` | Allows clearing the selected date and setting the value to `null` |
+| `allowOutsideInterval` | `Boolean` | `false` | Allows user to click dates outside of current interval |
+
 
 ## Compatibility
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -93,6 +93,14 @@ Disables datepicker and prevents it's opening
 
 Allows user to input date manually
 
+### `allowOutsideInterval`
+
+-   Type: `Boolean`
+-   Default: `false`
+
+Allows user to click dates outside of current interval.
+
+
 ## Styling
 
 The input itself can be styled via passing classes to it. [Attribute fallthrough](https://v3.vuejs.org/guide/component-attrs.html#disabling-attribute-inheritance) is enabled. Keep in mind that input itself is not a top-level element, as it is contained within the top-level `div`.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "author": {
-    "email": "christopher.smoak@gmail.com",
-    "name": "Christopher Smoak"
+    "email": "icehaunter@gmail.com",
+    "name": "Ilya Borovitinov"
   },
   "license": "MIT",
   "engines": {
@@ -15,8 +15,8 @@
     "url": "https://github.com/icehaunter/vue3-datepicker/issues"
   },
   "private": false,
-  "name": "vue3-datepicker-smoakey",
-  "version": "0.2.6",
+  "name": "vue3-datepicker",
+  "version": "0.2.5",
   "publishConfig": {
     "access": "public"
   },

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "author": {
-    "email": "icehaunter@gmail.com",
-    "name": "Ilya Borovitinov"
+    "email": "christopher.smoak@gmail.com",
+    "name": "Christopher Smoak"
   },
   "license": "MIT",
   "engines": {
@@ -15,7 +15,7 @@
     "url": "https://github.com/icehaunter/vue3-datepicker/issues"
   },
   "private": false,
-  "name": "vue3-datepicker",
+  "name": "vue3-datepicker-smoakey22",
   "version": "0.2.5",
   "publishConfig": {
     "access": "public"

--- a/package.json
+++ b/package.json
@@ -15,8 +15,8 @@
     "url": "https://github.com/icehaunter/vue3-datepicker/issues"
   },
   "private": false,
-  "name": "vue3-datepicker-smoakey22",
-  "version": "0.2.5",
+  "name": "vue3-datepicker-smoakey",
+  "version": "0.2.6",
   "publishConfig": {
     "access": "public"
   },

--- a/src/App.vue
+++ b/src/App.vue
@@ -18,6 +18,18 @@
   <div>
     <datepicker
       class="picker"
+      v-model="selected"
+      :locale="locale"
+      :upperLimit="to"
+      :lowerLimit="from"
+      :clearable="true"
+			:disabledDates="{ predicate: isToday }"
+      :allow-outside-interval="true"
+    />
+  </div>
+  <div>
+    <datepicker
+      class="picker"
       weekday-format="iiiiii"
       month-list-format="LLLL"
       v-model="from"

--- a/src/App.vue
+++ b/src/App.vue
@@ -25,6 +25,7 @@
       :clearable="true"
       :disabledDates="{ predicate: isToday }"
       :allow-outside-interval="true"
+      placeholder="allow outside interval"
     />
   </div>
   <div>

--- a/src/App.vue
+++ b/src/App.vue
@@ -23,7 +23,7 @@
       :upperLimit="to"
       :lowerLimit="from"
       :clearable="true"
-			:disabledDates="{ predicate: isToday }"
+      :disabledDates="{ predicate: isToday }"
       :allow-outside-interval="true"
     />
   </div>

--- a/src/datepicker/Datepicker.vue
+++ b/src/datepicker/Datepicker.vue
@@ -51,6 +51,7 @@
       :disabledDates="disabledDates"
       :locale="locale"
       :weekdayFormat="weekdayFormat"
+      :allow-outside-interval="allowOutsideInterval"
       @select="selectDay"
       @back="viewShown = 'month'"
     />
@@ -202,6 +203,14 @@ export default defineComponent({
       default: 'day',
       validate: (v: unknown) =>
         typeof v === 'string' && TIME_RESOLUTIONS.includes(v),
+    },
+    /*
+     * Allow clicking dates in past or next months
+     */
+    allowOutsideInterval: {
+      type: Boolean,
+      required: false,
+      default: false,
     },
   },
   emits: {

--- a/src/datepicker/DayPicker.vue
+++ b/src/datepicker/DayPicker.vue
@@ -95,6 +95,11 @@ export default defineComponent({
       type: Object as PropType<{ dates?: Date[], predicate?: (target: Date) => boolean }>,
       required: false,
     },
+    allowOutsideInterval: {
+      type: Boolean,
+      required: false,
+      default: false,
+    },
   },
   setup(props, { emit }) {
     const format = computed(() =>
@@ -154,7 +159,7 @@ export default defineComponent({
         display: dayFormat(value),
         selected: props.selected && isSameDay(props.selected, value),
         disabled:
-          !isWithinInterval(value, currentMonth.value) ||
+          (!props.allowOutsideInterval && !isWithinInterval(value, currentMonth.value)) ||
           !isEnabled(value, props.lowerLimit, props.upperLimit, props.disabledDates),
         key: format.value('yyyy-MM-dd', value),
       }))


### PR DESCRIPTION
Allow the user to click on dates that are in previous or future months. 

This feature is opt-in via the `allowOutsideInterval` parameter.

Issue: #58 