### PR TITLE
Fixes datepicker labels in upper and lower limits example

### DIFF
--- a/docs/examples.md
+++ b/docs/examples.md
@@ -55,8 +55,8 @@ If limit is within the current "view" (e.g. a month), then view changing will be
 
 Settings: 
 
-- Upper limit: <datepicker v-model="example2_from" />
-- Lower limit: <datepicker v-model="example2_to" />
+- Lower limit: <datepicker v-model="example2_from" />
+- Upper limit: <datepicker v-model="example2_to" />
 
 Result:
 


### PR DESCRIPTION
The labels were in the wrong order - not corresponding to the respective datepickers.